### PR TITLE
fix issue #30: Module build failed: SyntaxError: Unexpected token

### DIFF
--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -40,7 +40,8 @@ module.exports = {
       {
         test: /\.js$/,
         loaders: ['babel'],
-        include: path.join(__dirname, 'src')
+        include: path.join(__dirname, 'src'),
+        query:{ presets:['react'] }
       },
       {
         test: /\.scss$/,


### PR DESCRIPTION
When run 'npm run dev', I got:

ERROR in ./src/index.js
Module build failed: SyntaxError: Unexpected token (19:2)

17 | 
18 | ReactDOM.render(

19 | ,
| ^
20 | document.getElementById('root')
21 | );
22 |
@ multi main
