### PR TITLE
change component from default export

### DIFF
--- a/src/containers/App.js
+++ b/src/containers/App.js
@@ -10,7 +10,7 @@ import Footer from '../components/Footer';
  * Again, this is because it serves to wrap the rest of our application with the Provider
  * component to make the Redux store available to the rest of the app.
  */
-export default class App extends Component {
+export class App extends Component {
   render() {
     // we can use ES6's object destructuring to effectively 'unpack' our props
     const { counter, actions } = this.props;


### PR DESCRIPTION
This fixes a compile error caused by two default exports.

Saw [this PR](https://github.com/tsaiDavid/simple-redux-boilerplate/pull/28)  but figured the component should also be exported for testing purposes, leaving container as the default. 